### PR TITLE
platform: add basic syntax highlighting for a shell session

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ highlight_theme = "css"
 highlight_themes_css = [
   { theme = "gruvbox-dark", filename = "syntax-theme.css" },
 ]
+extra_syntaxes_and_themes = ["syntaxes"]
 
 [link_checker]
 skip_prefixes = [

--- a/sass/additional.scss
+++ b/sass/additional.scss
@@ -2,3 +2,16 @@ footer p.licensing {
     color: var(--text-accent-color);
     font-size: 60%;
 }
+
+// Colors are from gruvbox-dark
+.z-shell-session {
+    .z-prompt {
+        color: #fabd2f;
+    }
+    .z-shell.z-source {
+        color: #b8bb26;
+    }
+    .z-output {
+        color: #fabd2f;
+    }
+}

--- a/syntaxes/Shell-Session.sublime-syntax
+++ b/syntaxes/Shell-Session.sublime-syntax
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+# Original source:
+#   https://github.com/atom/language-shellscript/blob/35dc1aa1371ab75ece08fd0837330eb62e1f9da9/grammars/shell-session.cson
+# Copyright (c) 2014 GitHub Inc.
+# Licensed under MIT.
+
+name: Shell Session
+file_extensions:
+  - sh-session
+scope: text.shell-session
+contexts:
+  main:
+    - match: '^(?:((?:\(\S+\)\s*)?(?:sh\S*?|\w+\S+[@:]\S+(?:\s+\S+)?|\[\S+?[@:][^\n]+?\].*?))\s*)?([>$#%❯➜]|\p{Greek})\s+(.*)$'
+      captures:
+        1: entity.other.prompt-prefix.shell-session
+        2: punctuation.separator.prompt.shell-session
+        3: source.shell
+    - match: ^.+$
+      scope: meta.output.shell-session


### PR DESCRIPTION
This is not super special, just distinguishing between the prompt, the command line, and output lines.